### PR TITLE
update OpenAPI spec

### DIFF
--- a/openapi/mt_openapi_spec_v1.yaml
+++ b/openapi/mt_openapi_spec_v1.yaml
@@ -3371,11 +3371,6 @@ components:
           description: For `ach`, this field will be passed through on an addenda
             record. For `wire` payments the field will be passed through as the "Originator
             to Beneficiary Information", also known as OBI or Fedwire tag 6000.
-      required:
-      - amount_upper_bound
-      - amount_lower_bound
-      - direction
-      - internal_account_id
     external_account:
       type: object
       properties:

--- a/openapi/mt_openapi_spec_v1.yaml
+++ b/openapi/mt_openapi_spec_v1.yaml
@@ -1455,7 +1455,7 @@ paths:
         content:
           application/json:
             schema:
-              "$ref": "#/components/schemas/payment_order_create_request"
+              "$ref": "#/components/schemas/payment_order_async_create_request"
   "/api/payment_orders":
     get:
       summary: list payment orders
@@ -4802,6 +4802,328 @@ components:
           description: An array of documents to be attached to the payment order.
             Note that if you attach documents, the request's content type must be
             `multipart/form-data`.
+      required:
+      - type
+      - amount
+      - direction
+      - originating_account_id
+    payment_order_async_create_request:
+      type: object
+      properties:
+        type:
+          type: string
+          enum:
+          - ach
+          - au_becs
+          - bacs
+          - book
+          - card
+          - check
+          - eft
+          - interac
+          - provxchange
+          - rtp
+          - sen
+          - sepa
+          - signet
+          - wire
+          description: One of `ach`, `eft`, `wire`, `check`, `sen`, `book`, `rtp`,
+            `sepa`, `bacs`, `au_becs`, `interac`, `signet`, `provexchange`.
+        subtype:
+          type: string
+          enum:
+          - CCD
+          - CIE
+          - CTX
+          - IAT
+          - PPD
+          - TEL
+          - WEB
+          nullable: true
+          description: An additional layer of classification for the type of payment
+            order you are doing. This field is only used for `ach` payment orders
+            currently. For `ach`  payment orders, the `subtype`  represents the SEC
+            code. We currently support `CCD`, `PPD`, `IAT`, `CTX`, `WEB`, `CIE`, and
+            `TEL`.
+        amount:
+          type: integer
+          description: Value in specified currency's smallest unit. e.g. $10 would
+            be represented as 1000 (cents). For RTP, the maximum amount allowed by
+            the network is $100,000.
+        direction:
+          type: string
+          enum:
+          - credit
+          - debit
+          description: One of `credit`, `debit`. Describes the direction money is
+            flowing in the transaction. A `credit` moves money from your account to
+            someone else's. A `debit` pulls money from someone else's account to your
+            own. Note that wire, rtp, and check payments will always be `credit`.
+        priority:
+          type: string
+          enum:
+          - high
+          - normal
+          description: Either `normal` or `high`. For ACH and EFT payments, `high`
+            represents a same-day ACH or EFT transfer, respectively. For check payments,
+            `high` can mean an overnight check rather than standard mail.
+        originating_account_id:
+          type: string
+          format: uuid
+          description: The ID of one of your organization's internal accounts.
+        receiving_account_id:
+          type: string
+          format: uuid
+          description: Either `receiving_account` or `receiving_account_id` must be
+            present. When using `receiving_account_id`, you may pass the id of an
+            external account or an internal account.
+        accounting_category_id:
+          type: string
+          format: uuid
+          nullable: true
+          description: The ID of one of your accounting categories. Note that these
+            will only be accessible if your accounting system has been connected.
+        accounting_ledger_class_id:
+          type: string
+          format: uuid
+          nullable: true
+          description: The ID of one of your accounting ledger classes. Note that
+            these will only be accessible if your accounting system has been connected.
+        currency:
+          "$ref": "#/components/schemas/currency"
+          description: Defaults to the currency of the originating account.
+        effective_date:
+          type: string
+          format: date
+          description: 'Date transactions are to be posted to the participants'' account.
+            Defaults to the current business day or the next business day if the current
+            day is a bank holiday or weekend. Format: yyyy-mm-dd.'
+        description:
+          type: string
+          nullable: true
+          description: An optional description for internal use.
+        statement_descriptor:
+          type: string
+          nullable: true
+          description: An optional descriptor which will appear in the receiver's
+            statement. For `check` payments this field will be used as the memo line.
+            For `ach` the maximum length is 10 characters. Note that for ACH payments,
+            the name on your bank account will be included automatically by the bank,
+            so you can use the characters for other useful information. For `eft`
+            the maximum length is 15 characters.
+        remittance_information:
+          type: string
+          nullable: true
+          description: For `ach`, this field will be passed through on an addenda
+            record. For `wire` payments the field will be passed through as the "Originator
+            to Beneficiary Information", also known as OBI or Fedwire tag 6000.
+        purpose:
+          type: string
+          nullable: true
+          description: For `wire`, this is usually the purpose which is transmitted
+            via the "InstrForDbtrAgt" field in the ISO20022 file. If you are using
+            Currencycloud, this is the `payment.purpose_code` field. For `eft`, this
+            field is the 3 digit CPA Code that will be attached to the payment.
+        metadata:
+          type: object
+          additionalProperties:
+            type: string
+          example:
+            key: value
+            foo: bar
+            modern: treasury
+          description: Additional data represented as key-value pairs. Both the key
+            and value must be strings.
+        charge_bearer:
+          type: string
+          enum:
+          - shared
+          - sender
+          - receiver
+          nullable: true
+          description: The party that will pay the fees for the payment order. Only
+            applies to wire payment orders. Can be one of shared, sender, or receiver,
+            which correspond respectively with the SWIFT 71A values `SHA`, `OUR`,
+            `BEN`.
+        foreign_exchange_indicator:
+          type: string
+          enum:
+          - fixed_to_variable
+          - variable_to_fixed
+          nullable: true
+          description: Indicates the type of FX transfer to initiate, can be either
+            `variable_to_fixed`, `fixed_to_variable`, or `null` if the payment order
+            currency matches the originating account currency.
+        foreign_exchange_contract:
+          type: string
+          nullable: true
+          description: If present, indicates a specific foreign exchange contract
+            number that has been generated by your financial institution.
+        nsf_protected:
+          type: boolean
+          description: A boolean to determine if NSF Protection is enabled for this
+            payment order. Note that this setting must also be turned on in your organization
+            settings page.
+        originating_party_name:
+          type: string
+          nullable: true
+          description: If present, this will replace your default company name on
+            receiver's bank statement. This field can only be used for ACH payments
+            currently. For ACH, only the first 16 characters of this string will be
+            used. Any additional characters will be truncated.
+        ultimate_originating_party_name:
+          type: string
+          nullable: true
+          description: Name of the ultimate originator of the payment order.
+        ultimate_originating_party_identifier:
+          type: string
+          nullable: true
+          description: Identifier of the ultimate originator of the payment order.
+        ultimate_receiving_party_name:
+          type: string
+          nullable: true
+          description: Name of the ultimate funds recipient.
+        ultimate_receiving_party_identifier:
+          type: string
+          nullable: true
+          description: Identifier of the ultimate funds recipient.
+        send_remittance_advice:
+          type: boolean
+          nullable: true
+          description: Send an email to the counterparty when the payment order is
+            sent to the bank. If `null`, `send_remittance_advice` on the Counterparty
+            is used.
+        fallback_type:
+          type: string
+          enum:
+          - ach
+          description: A payment type to fallback to if the original type is not valid
+            for the receiving account. Currently, this only supports falling back
+            from RTP to ACH (type=rtp and fallback_type=ach)
+        receiving_account:
+          type: object
+          properties:
+            account_type:
+              type: string
+              enum:
+              - checking
+              - other
+              - savings
+              description: Can be `checking`, `savings` or `other`.
+            party_type:
+              type: string
+              enum:
+              - business
+              - individual
+              nullable: true
+              description: Either `individual` or `business`.
+            party_address:
+              "$ref": "#/components/schemas/address_request"
+              description: Required if receiving wire payments.
+            name:
+              type: string
+              nullable: true
+              description: A nickname for the external account. This is only for internal
+                usage and won't affect any payments
+            account_details:
+              type: array
+              items:
+                type: object
+                properties:
+                  account_number:
+                    type: string
+                  account_number_type:
+                    type: string
+                    enum:
+                    - iban
+                    - clabe
+                    - wallet_address
+                    - pan
+                    - other
+                required:
+                - account_number
+            routing_details:
+              type: array
+              items:
+                type: object
+                properties:
+                  routing_number:
+                    type: string
+                  routing_number_type:
+                    type: string
+                    enum:
+                    - aba
+                    - swift
+                    - au_bsb
+                    - ca_cpa
+                    - cnaps
+                    - gb_sort_code
+                    - in_ifsc
+                    - my_branch_code
+                    - br_codigo
+                  payment_type:
+                    type: string
+                    enum:
+                    - ach
+                    - au_becs
+                    - bacs
+                    - book
+                    - card
+                    - check
+                    - eft
+                    - interac
+                    - provxchange
+                    - rtp
+                    - sen
+                    - sepa
+                    - signet
+                    - wire
+                required:
+                - routing_number
+                - routing_number_type
+            metadata:
+              type: object
+              additionalProperties:
+                type: string
+              example:
+                key: value
+                foo: bar
+                modern: treasury
+              description: Additional data represented as key-value pairs. Both the
+                key and value must be strings.
+            party_name:
+              type: string
+              description: If this value isn't provided, it will be inherited from
+                the counterparty's name.
+            party_identifier:
+              type: string
+            plaid_processor_token:
+              type: string
+              description: If you've enabled the Modern Treasury + Plaid integration
+                in your Plaid account, you can pass the processor token in this field.
+            contact_details:
+              type: array
+              items:
+                "$ref": "#/components/schemas/contact_detail_create_request"
+          description: Either `receiving_account` or `receiving_account_id` must be
+            present. When using `receiving_account_id`, you may pass the id of an
+            external account or an internal account.
+        ledger_transaction:
+          "$ref": "#/components/schemas/ledger_transaction_create_request"
+          description: Specifies a ledger transaction object that will be created
+            with the payment order. If the ledger transaction cannot be created, then
+            the payment order creation will fail. The resulting ledger transaction
+            will mirror the status of the payment order.
+        line_items:
+          type: array
+          items:
+            "$ref": "#/components/schemas/line_item_request"
+          description: An array of line items that must sum up to the amount of the
+            payment order.
+        transaction_monitoring_enabled:
+          type: boolean
+          description: A flag that determines whether a payment order should go through
+            transaction monitoring.
       required:
       - type
       - amount

--- a/openapi/mt_openapi_spec_v1.yaml
+++ b/openapi/mt_openapi_spec_v1.yaml
@@ -896,6 +896,8 @@ paths:
           - ach
           - book
           - check
+          - eft
+          - interac
           - rtp
           - sepa
           - signet
@@ -1692,6 +1694,12 @@ paths:
                 "$ref": "#/components/schemas/payment_order"
         '422':
           description: parameter_invalid
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/error_message"
+        '404':
+          description: not found
           content:
             application/json:
               schema:
@@ -3700,6 +3708,8 @@ components:
           - ach
           - book
           - check
+          - eft
+          - interac
           - rtp
           - sepa
           - signet
@@ -3820,6 +3830,10 @@ components:
             modern: treasury
           description: Additional data represented as key-value pairs. Both the key
             and value must be strings.
+        parent_account_id:
+          type: string
+          format: uuid
+          nullable: true
       additionalProperties: false
       minProperties: 15
     internal_account_create_request:
@@ -3846,6 +3860,9 @@ components:
         entity_id:
           type: string
           description: The identifier of the entity at Increase which owns the account.
+        parent_account_id:
+          type: string
+          description: The parent internal account of this new account.
       required:
       - connection_id
       - name
@@ -3863,6 +3880,9 @@ components:
             type: string
           description: Additional data in the form of key-value pairs. Pairs can be
             removed by passing an empty string or `null` as the value.
+        parent_account_id:
+          type: string
+          description: The parent internal account for this account.
     ledger_entry:
       type: object
       properties:
@@ -5165,6 +5185,7 @@ components:
           - cross_river_transaction_id
           - currencycloud_conversion_id
           - currencycloud_payment_id
+          - dc_bank_transaction_id
           - dwolla_transaction_id
           - eft_trace_number
           - fedwire_imad
@@ -5175,10 +5196,12 @@ components:
           - goldman_sachs_payment_request_id
           - goldman_sachs_request_id
           - goldman_sachs_unique_payment_id
+          - interac_message_id
           - jpmc_ccn
           - jpmc_end_to_end_id
           - jpmc_firm_root_id
           - jpmc_p3_id
+          - jpmc_payment_batch_id
           - jpmc_payment_information_id
           - lob_check_id
           - other
@@ -5194,7 +5217,7 @@ components:
           - silvergate_payment_id
           - swift_mir
           - swift_uetr
-          - usbank_transaction_id
+          - usbank_payment_id
           - wells_fargo_payment_id
           - wells_fargo_trace_number
           description: The type of the reference number. Referring to the vendor payment
@@ -5338,6 +5361,7 @@ components:
           - au_becs
           - bacs
           - eft
+          - interac
           - manual
           - paper_item
           - wire
@@ -5686,6 +5710,7 @@ components:
           - signet
           - silvergate
           - swift
+          - us_bank
           nullable: true
           description: The type of vendor_code being reported. Can be one of `bai2`,
             `swift`, `cleartouch`, or `silvergate`.


### PR DESCRIPTION
Everything is additive except for the change from `usbank_transaction_id` to `usbank_payment_id` which would be a breaking change but we can ship this into the initial version without a version bump. 