### PR TITLE
Add swagger ui index page for a hosted github page of our open api spec

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,27 @@
+<html>
+    <head>
+        <script src="https://unpkg.com/swagger-ui-dist@3/swagger-ui-bundle.js"></script>
+        <link rel="stylesheet" type="text/css" href="https://unpkg.com/swagger-ui-dist@3/swagger-ui.css"/>
+        <title>Modern Treasury</title>
+    </head>
+    <body>
+        <div id="swagger-ui"></div>
+        <script>
+            window.onload = function () {
+                const ui = SwaggerUIBundle({
+                    url: "openapi/mt_openapi_spec_v1.yaml",
+                    dom_id: '#swagger-ui',
+                    deepLinking: true,
+                    presets: [
+                        SwaggerUIBundle.presets.apis,
+                        SwaggerUIBundle.SwaggerUIStandalonePreset
+                    ],
+                    plugins: [
+                        SwaggerUIBundle.plugins.DownloadUrl
+                    ],
+                })
+                window.ui = ui
+            }
+        </script>
+    </body>
+</html>

--- a/index.html
+++ b/index.html
@@ -1,27 +1,27 @@
 <html>
-    <head>
-        <script src="https://unpkg.com/swagger-ui-dist@3/swagger-ui-bundle.js"></script>
-        <link rel="stylesheet" type="text/css" href="https://unpkg.com/swagger-ui-dist@3/swagger-ui.css"/>
-        <title>Modern Treasury</title>
-    </head>
-    <body>
-        <div id="swagger-ui"></div>
-        <script>
-            window.onload = function () {
-                const ui = SwaggerUIBundle({
-                    url: "openapi/mt_openapi_spec_v1.yaml",
-                    dom_id: '#swagger-ui',
-                    deepLinking: true,
-                    presets: [
-                        SwaggerUIBundle.presets.apis,
-                        SwaggerUIBundle.SwaggerUIStandalonePreset
-                    ],
-                    plugins: [
-                        SwaggerUIBundle.plugins.DownloadUrl
-                    ],
-                })
-                window.ui = ui
-            }
-        </script>
-    </body>
+  <head>
+    <script src="https://unpkg.com/swagger-ui-dist@3/swagger-ui-bundle.js"></script>
+    <link rel="stylesheet" type="text/css" href="https://unpkg.com/swagger-ui-dist@3/swagger-ui.css"/>
+    <title>Modern Treasury</title>
+  </head>
+  <body>
+    <div id="swagger-ui"></div>
+    <script>
+      window.onload = function () {
+        const ui = SwaggerUIBundle({
+          url: "openapi/mt_openapi_spec_v1.yaml",
+          dom_id: '#swagger-ui',
+          deepLinking: true,
+          presets: [
+            SwaggerUIBundle.presets.apis,
+            SwaggerUIBundle.SwaggerUIStandalonePreset
+          ],
+          plugins: [
+            SwaggerUIBundle.plugins.DownloadUrl
+          ],
+        })
+        window.ui = ui
+      }
+    </script>
+  </body>
 </html>


### PR DESCRIPTION
Per request to have a hosted swagger ui as a github page