### PR TITLE
fixes server url

### DIFF
--- a/openapi/mt_openapi_spec_v1.yaml
+++ b/openapi/mt_openapi_spec_v1.yaml
@@ -4728,7 +4728,7 @@ paths:
                 "$ref": "#/components/schemas/virtual_account"
 servers:
 - url: http://localhost:3000
-- url: app.moderntreasury.com
+- url: https://app.moderntreasury.com
 components:
   securitySchemes:
     basic_auth:


### PR DESCRIPTION
When attempting to use the MT OpenAPI with Retool (for example), having the full server URL is necessary.