### PR TITLE
Add ledger_account_update_request to bulk_request_create_request schema

### DIFF
--- a/openapi/mt_openapi_spec_v1.yaml
+++ b/openapi/mt_openapi_spec_v1.yaml
@@ -9702,6 +9702,13 @@ components:
                   id:
                     type: string
                     format: uuid
+            - allOf:
+              - "$ref": "#/components/schemas/ledger_account_update_request"
+              - type: object
+                properties:
+                  id:
+                    type: string
+                    format: uuid
       required:
       - action_type
       - resource_type


### PR DESCRIPTION
## Summary
Add `ledger_account_update_request` to the `resources` items `oneOf` in `bulk_request_create_request`, enabling SDK clients to use bulk update for ledger accounts.

Corresponds to monorepo PR: https://github.com/Modern-Treasury/monorepo/pull/48884

## Review & Testing Checklist for Human
- [ ] Verify the `ledger_account_update_request` ref is correctly placed in the oneOf list with the allOf + id pattern matching other update request types

### Notes
The delete case is already handled by the existing generic `id`-only object in the oneOf. Once merged, this should trigger Stainless to regenerate SDKs including Kotlin.

Link to Devin session: https://app.devin.ai/sessions/aba8ac48fbb54d1d80b8b613ec0bbd33
Requested by: @cnrmrphy